### PR TITLE
PUT method required Content-Length header while requested through proxy server

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -53,6 +53,7 @@ class Curl {
 		$options[CURLOPT_URL] = $url;
 		$options[CURLOPT_PUT] = true;
 		$options[CURLOPT_RETURNTRANSFER] = true;
+		$options[CURLOPT_INFILESIZE] = 0;
 
 		return self::_exec($options);
 	}


### PR DESCRIPTION
Content-Length header required while requested through proxy server, e.g. nginx, otherwise "411 Length Required" returned. It is better to set zero Content-Length on PUT request to avoid it.

http://stackoverflow.com/questions/15619562/getting-411-length-required-after-a-put-request-from-http-client
http://serverfault.com/questions/164220/is-there-a-way-to-avoid-nginx-411-content-length-required-errors
