### PR TITLE
Auto-adding content-length heading to fix append-command bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .buildpath
 .project
 .settings/
+.idea/
 vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "PHP WebHDFS, forked from https://github.com/simpleenergy/php-WebHDFS",
   "minimum-stability": "stable",
   "license": "MIT",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "authors": [
     {
       "name": "tranch-xiao",

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -17,11 +17,13 @@ class Curl
     {
         $this->debug = $debug;
     }
+
     /**
      *
      * @param $localPath string local file path to save
      */
-    public function setOption($key,$value) {
+    public function setOption($key, $value)
+    {
         $this->options[$key] = $value;
     }
 
@@ -213,13 +215,9 @@ class Curl
         if (!$has_content_length_header && !isset($options[CURLOPT_INFILE]) && !isset($options[CURLOPT_INFILESIZE])) {
             $length = 0;
             if (isset($options[CURLOPT_POSTFIELDS])) {
-                if (function_exists('mb_strlen')) {
-                    $length = mb_strlen($options[CURLOPT_POSTFIELDS]);
-                } else {
-                    $length = strlen($options[CURLOPT_POSTFIELDS]);
-                }
+                $length = strlen($options[CURLOPT_POSTFIELDS]);
             }
-            $options[CURLOPT_HTTPHEADER] = array_merge($options[CURLOPT_HTTPHEADER], ['Content-Length: '.$length]);
+            $options[CURLOPT_HTTPHEADER] = array_merge($options[CURLOPT_HTTPHEADER], ['Content-Length: ' . $length]);
         }
 
         curl_setopt_array($ch, $options);

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -213,11 +213,17 @@ class Curl
             }
         }
         if (!$has_content_length_header && !isset($options[CURLOPT_INFILE]) && !isset($options[CURLOPT_INFILESIZE])) {
-            $length = 0;
             if (isset($options[CURLOPT_POSTFIELDS])) {
-                $length = strlen($options[CURLOPT_POSTFIELDS]);
+                // only for string content
+                if (is_string($options[CURLOPT_POSTFIELDS]) && strpos($options[CURLOPT_POSTFIELDS], '@') !== 0) {
+                    $options[CURLOPT_HTTPHEADER] = array_merge(
+                        $options[CURLOPT_HTTPHEADER],
+                        ['Content-Length: '.strlen($options[CURLOPT_POSTFIELDS])]
+                    );
+                }
+            } else {
+                $options[CURLOPT_HTTPHEADER] = array_merge($options[CURLOPT_HTTPHEADER], ['Content-Length: 0']);
             }
-            $options[CURLOPT_HTTPHEADER] = array_merge($options[CURLOPT_HTTPHEADER], ['Content-Length: ' . $length]);
         }
 
         curl_setopt_array($ch, $options);


### PR DESCRIPTION
Sending an `APPEND` command is a two-step process. The first POST request is sent with `Content-Length: -1` header, which returns in a `Bad Request` response. Setting it to `0` fixes this issue.