### PR TITLE
Remove invalid option for curl_setopt_array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "PHP WebHDFS, forked from https://github.com/simpleenergy/php-WebHDFS",
   "minimum-stability": "stable",
   "license": "MIT",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "authors": [
     {
       "name": "tranch-xiao",

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -63,7 +63,6 @@ class Curl
     {
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_HEADER] = true;
-        $options[CURLINFO_EFFECTIVE_URL] = true;
         $options[CURLOPT_RETURNTRANSFER] = true;
         $header = $this->_exec($options);
         $matches = array();


### PR DESCRIPTION
### why

This change removes an invalid option for `curl_setopt_array`. 

This closes https://github.com/michaelbutler/php-WebHDFS/issues/24

[All valid options.](https://www.php.net/manual/en/function.curl-setopt.php)