### PR TITLE
Allow for CURL options to be set, and expose errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "PHP WebHDFS, forked from https://github.com/simpleenergy/php-WebHDFS",
   "minimum-stability": "stable",
   "license": "MIT",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "authors": [
     {
       "name": "tranch-xiao",

--- a/src/org/apache/hadoop/WebHDFS.php
+++ b/src/org/apache/hadoop/WebHDFS.php
@@ -44,6 +44,23 @@ class WebHDFS
         return $this->curl;
     }
 
+    /**
+     * Get the result of the last CURL command.
+     * @return mixed
+     */
+    public function getLastRequestContentResult()
+    {
+        return $this->getCurl()->getLastRequestContentResult();
+    }
+
+    /**
+     * @return array
+     */
+    public function getLastRequestInfoResult()
+    {
+        return $this->getCurl()->getLastRequestInfoResult();
+    }
+
     // File and Directory Operations
 
     public function create(

--- a/src/org/apache/hadoop/WebHDFS.php
+++ b/src/org/apache/hadoop/WebHDFS.php
@@ -46,6 +46,7 @@ class WebHDFS
 
     /**
      * Get the result of the last CURL command.
+     *
      * @return mixed
      */
     public function getLastRequestContentResult()
@@ -54,6 +55,9 @@ class WebHDFS
     }
 
     /**
+     * Get the curl info from the last CURL call.
+     * @link https://www.php.net/manual/en/function.curl-getinfo.php
+     *
      * @return array
      */
     public function getLastRequestInfoResult()

--- a/src/org/apache/hadoop/WebHDFS.php
+++ b/src/org/apache/hadoop/WebHDFS.php
@@ -24,7 +24,8 @@ class WebHDFS
         $user,
         $namenodeRpcHost,
         $namenodeRpcPort,
-        $debug
+        $curl_options = [],
+        $debug = false
     ) {
         $this->host = $host;
         $this->port = $port;
@@ -32,7 +33,15 @@ class WebHDFS
         $this->namenode_rpc_host = $namenodeRpcHost;
         $this->namenode_rpc_port = $namenodeRpcPort;
         $this->debug = $debug;
-        $this->curl = new Curl($this->debug);
+        $this->curl = new Curl($curl_options, $this->debug);
+    }
+
+    /**
+     * @return Curl
+     */
+    public function getCurl()
+    {
+        return $this->curl;
     }
 
     // File and Directory Operations

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -20,10 +20,17 @@ class Curl
 
     public function __construct($curl_options = [], $debug = false)
     {
-        $this->curl_options = $curl_options;
+        $this->setCurlOptions($curl_options);
         $this->debug = $debug;
     }
 
+    /**
+     * Set an array of curl options. Keys are CURLOPT_* constants, values are the value to be set.
+     * @see https://www.php.net/manual/en/function.curl-setopt-array.php
+     *
+     * @param array $curl_options Array of curl options to set
+     * @return void
+     */
     public function setCurlOptions(array $curl_options)
     {
         $this->curl_options = $curl_options;

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -223,6 +223,11 @@ class Curl
             return false;
         }
 
+        $curl_errno = $this->getLastRequestInfoResult()['curl_errno'];
+        if ($curl_errno !== CURLE_OK) {
+            return false;
+        }
+
         if ($cleanLastRequestIfValid) {
             $this->cleanLastRequest();
         }

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -215,7 +215,7 @@ class Curl
     private function _exec($options, $returnInfo = false)
     {
         $ch = curl_init();
-        $options = array_merge($this->curl_options, $options);
+        $options += $this->curl_options;
 
         if ($this->debug === true) {
             $options[CURLOPT_VERBOSE] = true;

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -84,6 +84,7 @@ class Curl
 
     private function _findRedirectUrl($url, $options)
     {
+        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_HEADER] = true;
         $options[CURLOPT_RETURNTRANSFER] = true;
@@ -100,6 +101,7 @@ class Curl
 
     public function putFile($url, $filename)
     {
+        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_PUT] = true;
         $handle = fopen($filename, "r");
@@ -113,6 +115,7 @@ class Curl
 
     public function putData($url, $data, $contentType = 'application/json')
     {
+        $options = array();
         $options[CURLOPT_URL] = $url;
         // $options[CURLOPT_PUT] = true;
         $options[CURLOPT_CUSTOMREQUEST] = 'PUT';
@@ -129,6 +132,7 @@ class Curl
 
     public function postString($url, $string)
     {
+        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_POST] = true;
         $options[CURLOPT_POSTFIELDS] = $string;
@@ -200,7 +204,7 @@ class Curl
         if ($http_code >= 400 && $http_code <= 500) {
             return false;
         }
-        
+
         if ($cleanLastRequestIfValid) {
             $this->cleanLastRequest();
         }

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -4,9 +4,15 @@ namespace org\apache\hadoop\tools;
 
 class Curl
 {
+    /** @var bool Optional debug flag, enables CURLOPT_VERBOSE */
     private $debug;
+
+    /** @var mixed Content result from the last CURL call */
     private $lastRequestContentResult;
+
+    /** @var array Info about last CURL result from curl_getinfo */
     private $lastRequestInfoResult;
+
     /**
      * @var array
      * curl options
@@ -173,6 +179,12 @@ class Curl
         return $this->_exec($options);
     }
 
+    /**
+     * Get the content form the last CURL call.
+     *
+     * @param bool $cleanLastRequest Clear the last CURL content result after getting.
+     * @return mixed
+     */
     public function getLastRequestContentResult($cleanLastRequest = false)
     {
         $r = $this->lastRequestContentResult;
@@ -183,6 +195,13 @@ class Curl
         return $r;
     }
 
+    /**
+     * Get the curl info from the last CURL call.
+     * @link https://www.php.net/manual/en/function.curl-getinfo.php
+     *
+     * @param bool $cleanLastRequest Clear last CURL info result after getting.
+     * @return array
+     */
     public function getLastRequestInfoResult($cleanLastRequest = false)
     {
         $r = $this->lastRequestInfoResult;

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -206,7 +206,7 @@ class Curl
     }
 
     /**
-     * Validate if the last CURL response is within the 2xx-3xx HTTP status code range.
+     * Validate if the last CURL response is within the 2xx-3xx HTTP status code range and has no curl errors.
      *
      * @param bool $cleanLastRequestIfValid Clear last CURL info result after getting.
      * @return bool

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -14,7 +14,8 @@ class Curl
     private $options;
 
     /**
-     * @var array $curl_options Key value array of curl options. @see https://www.php.net/manual/en/function.curl-setopt.php
+     * @var array $curl_options Key value array of curl options.
+     * @link https://www.php.net/manual/en/function.curl-setopt.php
      */
     private $curl_options;
 
@@ -26,7 +27,7 @@ class Curl
 
     /**
      * Set an array of curl options. Keys are CURLOPT_* constants, values are the value to be set.
-     * @see https://www.php.net/manual/en/function.curl-setopt-array.php
+     * @link https://www.php.net/manual/en/function.curl-setopt-array.php
      *
      * @param array $curl_options Array of curl options to set
      * @return void

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -13,9 +13,20 @@ class Curl
      */
     private $options;
 
-    public function __construct($debug = false)
+    /**
+     * @var array $curl_options Key value array of curl options. @see https://www.php.net/manual/en/function.curl-setopt.php
+     */
+    private $curl_options;
+
+    public function __construct($curl_options = [], $debug = false)
     {
+        $this->curl_options = $curl_options;
         $this->debug = $debug;
+    }
+
+    public function setCurlOptions(array $curl_options)
+    {
+        $this->curl_options = $curl_options;
     }
 
     /**
@@ -182,6 +193,8 @@ class Curl
     private function _exec($options, $returnInfo = false)
     {
         $ch = curl_init();
+        $options = array_merge($this->curl_options, $options);
+
         if ($this->debug === true) {
             $options[CURLOPT_VERBOSE] = true;
         }
@@ -231,6 +244,8 @@ class Curl
         $result = curl_exec($ch);
         $this->lastRequestContentResult = $result;
         $this->lastRequestInfoResult = curl_getinfo($ch);
+        $this->lastRequestInfoResult['curl_errno'] = curl_errno($ch);
+        $this->lastRequestInfoResult['curl_error'] = curl_error($ch);
         if ($returnInfo) {
             $result = $this->lastRequestInfoResult;
         }

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -88,9 +88,8 @@ class Curl
         return $this->_findRedirectUrl($url, array(CURLOPT_POST => true));
     }
 
-    private function _findRedirectUrl($url, $options)
+    private function _findRedirectUrl($url, $options = [])
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_HEADER] = true;
         $options[CURLOPT_RETURNTRANSFER] = true;

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -192,9 +192,15 @@ class Curl
     public function validateLastRequest($cleanLastRequestIfValid = false)
     {
         $http_code = $this->getLastRequestInfoResult()['http_code'];
+
+        if (!$http_code) {
+            return false;
+        }
+
         if ($http_code >= 400 && $http_code <= 500) {
             return false;
         }
+        
         if ($cleanLastRequestIfValid) {
             $this->cleanLastRequest();
         }

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -104,9 +104,8 @@ class Curl
         return null;
     }
 
-    public function putFile($url, $filename)
+    public function putFile($url, $filename, $options = array())
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_PUT] = true;
         $handle = fopen($filename, "r");
@@ -118,9 +117,8 @@ class Curl
         return ('201' == $info['http_code']);
     }
 
-    public function putData($url, $data, $contentType = 'application/json')
+    public function putData($url, $data, $options = array())
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         // $options[CURLOPT_PUT] = true;
         $options[CURLOPT_CUSTOMREQUEST] = 'PUT';
@@ -135,9 +133,8 @@ class Curl
         return ('201' == $info['http_code']);
     }
 
-    public function postString($url, $string)
+    public function postString($url, $string, $options = array())
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_POST] = true;
         $options[CURLOPT_POSTFIELDS] = $string;
@@ -147,9 +144,8 @@ class Curl
         return ('200' == $info['http_code']);
     }
 
-    public function put($url)
+    public function put($url, $options = array())
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_PUT] = true;
         $options[CURLOPT_RETURNTRANSFER] = true;
@@ -158,9 +154,8 @@ class Curl
         return $this->_exec($options);
     }
 
-    public function post($url)
+    public function post($url, $options = array())
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_POST] = true;
         $options[CURLOPT_RETURNTRANSFER] = true;
@@ -168,9 +163,8 @@ class Curl
         return $this->_exec($options);
     }
 
-    public function delete($url)
+    public function delete($url, $options = array())
     {
-        $options = array();
         $options[CURLOPT_URL] = $url;
         $options[CURLOPT_CUSTOMREQUEST] = "DELETE";
         $options[CURLOPT_RETURNTRANSFER] = true;
@@ -211,6 +205,12 @@ class Curl
         return $r;
     }
 
+    /**
+     * Validate if the last CURL response is within the 2xx-3xx HTTP status code range.
+     *
+     * @param bool $cleanLastRequestIfValid Clear last CURL info result after getting.
+     * @return bool
+     */
     public function validateLastRequest($cleanLastRequestIfValid = false)
     {
         $http_code = $this->getLastRequestInfoResult()['http_code'];

--- a/src/org/apache/hadoop/tools/Curl.php
+++ b/src/org/apache/hadoop/tools/Curl.php
@@ -19,6 +19,10 @@ class Curl
      */
     private $curl_options;
 
+    /**
+     * @param array $curl_options Key value array of curl options. @link https://www.php.net/manual/en/function.curl-setopt.php
+     * @param bool $debug Optional debug parameter, sets CURLOPT_VERBOSE if true.
+     */
     public function __construct($curl_options = [], $debug = false)
     {
         $this->setCurlOptions($curl_options);


### PR DESCRIPTION
Hi Michael, hope you're well.

Here's a patch to allow setting of CURL options and exposing curl errors.
We are investigating some errors with this library hanging indefinitely. I believe this to be due to no CURL timeouts being set, but not totally sure. 

This patch will allow us to set whatever CURL options we want, including `CURLOPT_CONNECTTIMEOUT` and `CURLOPT_TIMEOUT`.

I also noticed that there doesn't appear to be and handling for if curl responds with an error, but I will leave that update to a future patch as this change will unblock me now and I am unsure how you might like to handle curl errors.